### PR TITLE
Link to pydata paris slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Browse online:
 [![Launch JupyterLite](./book/images/jupyterbook_badge.svg 'Our JupyterBook
 website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/) [![Launch
 JupyterLite](./book/images/jupyterlite_badge.svg 'Our JupyterLite
-website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite)
+website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite/tree/notebooks)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Browse online:
 [![Launch JupyterLite](./book/images/jupyterbook_badge.svg 'Our JupyterBook
 website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/) [![Launch
 JupyterLite](./book/images/jupyterlite_badge.svg 'Our JupyterLite
-website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite/tree/notebooks)
+website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite/tree)
 
 ## Getting started
 

--- a/book/intro.md
+++ b/book/intro.md
@@ -11,7 +11,7 @@ and how to derive optimal decision policies for a user specified cost model.
 
 - [Video of the presentation made at PyData Paris 2024](https://www.youtube.com/watch?v=-gYnfA0e5ic)
 
-### Notebooks [![Launch JupyterLite](/images/jupyterlite_badge.svg 'Our JupyterLite website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite/tree/notebooks)
+### Notebooks [![Launch JupyterLite](/images/jupyterlite_badge.svg 'Our JupyterLite website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite/tree)
 
 ```{tableofcontents}
 ```

--- a/book/intro.md
+++ b/book/intro.md
@@ -7,9 +7,11 @@ and how to derive optimal decision policies for a user specified cost model.
 
 ### Slides
 
-[Introductory concepts](https://docs.google.com/presentation/d/1EW3alaVuUKzk8aCWONxpBQQ1LqCmFHNixIwbnfgjuSA/edit?usp=sharing)
+- [Introductory concepts](https://docs.google.com/presentation/d/1EBCSCDQ3nTPaKZGx9ZLWXfvkD1Y-ODo9j_ETAnx5zLQ/edit?usp=sharing)
 
-### Notebooks [![Launch JupyterLite](/images/jupyterlite_badge.svg 'Our JupyterLite website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite)
+- [Video of the presentation made at PyData Paris 2024](https://www.youtube.com/watch?v=-gYnfA0e5ic)
+
+### Notebooks [![Launch JupyterLite](/images/jupyterlite_badge.svg 'Our JupyterLite website')](https://probabl-ai.github.io/calibration-cost-sensitive-learning/jupyterlite/tree/notebooks)
 
 ```{tableofcontents}
 ```


### PR DESCRIPTION
- I linked to the slides of my keynote because they have a better flow between the concepts we introduce in this tutorial (and there are many bonus slides). I also linked to the PyData Paris video recording.

- The tree (traditional notebook) view of jupyterlite opens one browser tab per notebook. This makes it less likely to crash chrome by opening several jupyterlite tabs within the same browser tab.