### PR TITLE
Revert to pyodide 0.27.1 to see if it fixes problems with the _generate_predictions.ipynb notebook

### DIFF
--- a/jupyterlite/jupyter-lite.json
+++ b/jupyterlite/jupyter-lite.json
@@ -3,7 +3,7 @@
     "jupyter-config-data": {
       "litePluginSettings": {
         "@jupyterlite/pyodide-kernel-extension:kernel": {
-          "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
+          "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide.js"
         }
       }
     }


### PR DESCRIPTION
Under firefox this notebook is known to trigger low level pyodide errors.

Let's see if those problems can happen with the previous version. Note, we need to serve this behind HTTPS to get the synchronized jupyterlite/pyodide filesystems to work: without it, it appears that the crashes never happen (e.g. trying with with local build served on http://localhost:8000).