### PR TITLE
Upgrade to pyodide 0.27.2

### DIFF
--- a/jupyterlite/jupyter-lite.json
+++ b/jupyterlite/jupyter-lite.json
@@ -3,7 +3,7 @@
     "jupyter-config-data": {
       "litePluginSettings": {
         "@jupyterlite/pyodide-kernel-extension:kernel": {
-          "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide.js"
+          "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
         }
       }
     }


### PR DESCRIPTION
Let's use the latest pyodide version as the crash reported in https://github.com/jupyterlite/jupyterlite/issues/1582 is not related to the pyodide version.